### PR TITLE
NOVU-32870:  Re-add streaming fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ gemfile:
   - Gemfile.rails60 # Min ruby 2.5.0
 matrix:
   exclude:
+    - rvm: 2.5.3
+      gemfile: Gemfile.rails42
     - rvm: 2.6.0
       gemfile: Gemfile.rails42
     - rvm: 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,16 @@ rvm:
   - 2.5.3
   - 2.6.0
 gemfile:
-  - Gemfile.rails41
   - Gemfile.rails42
-  - Gemfile.rails50 # Min ruby 2.2.2
   - Gemfile.rails51 # Min ruby 2.2.2
+  - Gemfile.rails60 # Min ruby 2.5.0
 matrix:
   exclude:
-    - rvm: 2.4.5
-      gemfile: Gemfile.rails41
-    - rvm: 2.5.3
-      gemfile: Gemfile.rails41
-    - rvm: 2.6.0
-      gemfile: Gemfile.rails41
     - rvm: 2.6.0
       gemfile: Gemfile.rails42
+    - rvm: 2.2.10
+      gemfile: Gemfile.rails60
+    - rvm: 2.3.8
+      gemfile: Gemfile.rails60
+    - rvm: 2.4.5
+      gemfile: Gemfile.rails60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
  Changelog
 ===========
 
+[v0.5.17.1](https://github.com/Apipie/apipie-rails/tree/v0.5.17.1) (2020-02-06)
+--------
+
+[Full Changelog](https://github.com/Apipie/apipie-rails/compare/v0.5.17...v0.5.17.1)
+
+- Fix issue that prevents streaming responses ([goronfreeman](https://github.com/goronfreeman/))
+
 [v0.5.17](https://github.com/Apipie/apipie-rails/tree/v0.5.17) (2020-01-20)
 --------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
  Changelog
 ===========
 
+[v0.5.17](https://github.com/Apipie/apipie-rails/tree/v0.5.17) (2020-01-20)
+--------
+
+[Full Changelog](https://github.com/Apipie/apipie-rails/compare/v0.5.16...v0.5.17)
+
+- Allows update metadata for methods [\#667](https://github.com/Apipie/apipie-rails/pull/667) ([speckins](https://github.com/speckins))
+
 [v0.5.16](https://github.com/Apipie/apipie-rails/tree/v0.5.16) (2019-05-22)
 --------
 
@@ -208,7 +215,7 @@ v0.3.2
 v0.3.1
 ------
 
-* Support for ``api!`` keyword in concerns 
+* Support for ``api!`` keyword in concerns
   [#322](https://github.com/Apipie/apipie-rails/pull/322) [@iNecas][]
 * More explicit ordering of the static dispatcher middleware
   [#315](https://github.com/Apipie/apipie-rails/pull/315) [@iNecas][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
  Changelog
 ===========
 
+[v0.5.16](https://github.com/Apipie/apipie-rails/tree/v0.5.16) (2019-05-22)
+--------
+
+[Full Changelog](https://github.com/Apipie/apipie-rails/compare/v0.5.15...v0.5.16)
+
+- Load file directly instead of using Rails constant [\#665](https://github.com/Apipie/apipie-rails/pull/665) ([speckins](https://github.com/speckins))
+
 [v0.5.15](https://github.com/Apipie/apipie-rails/tree/v0.5.15) (2019-01-03)
 --------
 [Full Changelog](https://github.com/Apipie/apipie-rails/compare/v0.5.14...v0.5.15)

--- a/Gemfile.rails41
+++ b/Gemfile.rails41
@@ -4,3 +4,4 @@ gemspec
 
 gem 'rails', '~> 4.1.0'
 gem 'mime-types', '~> 2.99.3'
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -4,6 +4,7 @@ gemspec
 
 gem 'rails', '~> 4.2.5'
 gem 'mime-types', '~> 2.99.3'
+gem 'sqlite3', '~> 1.3.6'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
   gem 'nokogiri', '~> 1.6.8'

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -10,3 +10,5 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1.0')
   gem 'nokogiri', '~> 1.6.8'
   gem 'rdoc', '~> 4.2.2'
 end
+
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -6,3 +6,4 @@ gem 'rails', '~> 5.0.0'
 gem 'mime-types', '~> 2.99.3'
 gem 'rails-controller-testing'
 
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails51
+++ b/Gemfile.rails51
@@ -5,3 +5,5 @@ gemspec
 gem 'rails', '~> 5.1.0.rc1'
 gem 'mime-types', '~> 2.99.3'
 gem 'rails-controller-testing'
+
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/Gemfile.rails60
+++ b/Gemfile.rails60
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem 'rails', '~> 6.0.0.rc1'
+gem 'mime-types', '~> 2.99.3'
+gem 'rails-controller-testing'
+gem 'rspec-rails', git: 'https://github.com/rspec/rspec-rails', branch: '4-0-dev'
+gem 'rspec-core', git: 'https://github.com/rspec/rspec-core'
+gem 'rspec-mocks', git: 'https://github.com/rspec/rspec-mocks'
+gem 'rspec-support', git: 'https://github.com/rspec/rspec-support'
+gem 'rspec-expectations', git: 'https://github.com/rspec/rspec-expectations'

--- a/Gemfile.rails60
+++ b/Gemfile.rails60
@@ -10,3 +10,5 @@ gem 'rspec-core', git: 'https://github.com/rspec/rspec-core'
 gem 'rspec-mocks', git: 'https://github.com/rspec/rspec-mocks'
 gem 'rspec-support', git: 'https://github.com/rspec/rspec-support'
 gem 'rspec-expectations', git: 'https://github.com/rspec/rspec-expectations'
+
+gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/lib/apipie-rails.rb
+++ b/lib/apipie-rails.rb
@@ -2,6 +2,8 @@ require 'i18n'
 require 'json'
 require 'active_support/hash_with_indifferent_access'
 
+require 'apipie/core_ext/route.rb'
+
 require "apipie/routing"
 require "apipie/markup"
 require "apipie/apipie_module"

--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -434,8 +434,7 @@ module Apipie
     end
 
     def load_controller_from_file(controller_file)
-      controller_class_name = controller_file.gsub(/\A.*\/app\/controllers\//,"").gsub(/\.\w*\Z/,"").camelize
-      controller_class_name.constantize
+      require_dependency controller_file
     end
 
     def ignored?(controller, method = nil)

--- a/lib/apipie/core_ext/route.rb
+++ b/lib/apipie/core_ext/route.rb
@@ -1,0 +1,10 @@
+begin
+  # Rails 4
+  ActionDispatch::Journey
+rescue NameError
+  # Rails 3
+  require 'journey'
+  Journey
+end::Route.class_eval do
+  attr_accessor :base_url
+end

--- a/lib/apipie/core_ext/route.rb
+++ b/lib/apipie/core_ext/route.rb
@@ -1,10 +1,9 @@
-begin
-  # Rails 4
-  ActionDispatch::Journey
-rescue NameError
-  # Rails 3
-  require 'journey'
-  Journey
-end::Route.class_eval do
-  attr_accessor :base_url
+module Apipie
+  module BaseUrlExtension
+    attr_accessor :base_url
+  end
+end
+
+class ActionDispatch::Journey::Route
+  include Apipie::BaseUrlExtension
 end

--- a/lib/apipie/extractor.rb
+++ b/lib/apipie/extractor.rb
@@ -15,15 +15,18 @@ class Apipie::Railtie
         end
       end
     end
-    app.middleware.use ::Apipie::Extractor::Recorder::Middleware
 
-    if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
-      ActionController::TestCase::Behavior.instance_eval do
-        prepend Apipie::Extractor::Recorder::FunctionalTestRecording
+    if Apipie.configuration.record
+      app.middleware.use ::Apipie::Extractor::Recorder::Middleware
+
+      if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
+        ActionController::TestCase::Behavior.instance_eval do
+          prepend Apipie::Extractor::Recorder::FunctionalTestRecording
+        end
+      else
+        ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
+        ActionController::TestCase::Behavior.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
       end
-    else
-      ActionController::TestCase.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
-      ActionController::TestCase::Behavior.send(:prepend, Apipie::Extractor::Recorder::FunctionalTestRecording)
     end
   end
 end

--- a/lib/apipie/method_description.rb
+++ b/lib/apipie/method_description.rb
@@ -17,7 +17,8 @@ module Apipie
 
     end
 
-    attr_reader :full_description, :method, :resource, :apis, :examples, :see, :formats, :metadata, :headers, :show
+    attr_reader :full_description, :method, :resource, :apis, :examples, :see, :formats, :headers, :show
+    attr_accessor :metadata
 
     def initialize(method, resource, dsl_data)
       @method = method.to_s

--- a/lib/apipie/routes_formatter.rb
+++ b/lib/apipie/routes_formatter.rb
@@ -16,7 +16,7 @@ module Apipie
     end
 
     def format_path(rails_route)
-      rails_route.path.spec.to_s.gsub('(.:format)', '')
+      File.join(rails_route.base_url, rails_route.path.spec.to_s.gsub('(.:format)', ''))
     end
 
     def format_verb(rails_route)

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -651,14 +651,15 @@ module Apipie
 
     def add_headers_from_hash(swagger_params_array, headers)
       swagger_headers = headers.map do |header|
-        {
+        header_hash = {
           name: header[:name],
           in: 'header',
           required: header[:options][:required],
           description: header[:description],
           type:  header[:options][:type] || 'string'
         }
-
+        header_hash[:default] = header[:options][:default] if header[:options][:default]
+        header_hash
       end
       swagger_params_array.push(*swagger_headers)
     end

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -129,6 +129,8 @@ module Apipie
           'array'
         elsif @type.ancestors.include? Numeric
           'numeric'
+        elsif @type.ancestors.include? File
+          'file'
         else
           'string'
         end

--- a/lib/apipie/version.rb
+++ b/lib/apipie/version.rb
@@ -1,3 +1,3 @@
 module Apipie
-  VERSION = '0.5.17'
+  VERSION = '0.5.17.1'
 end

--- a/lib/apipie/version.rb
+++ b/lib/apipie/version.rb
@@ -1,3 +1,3 @@
 module Apipie
-  VERSION = '0.5.16'
+  VERSION = '0.5.17'
 end

--- a/lib/apipie/version.rb
+++ b/lib/apipie/version.rb
@@ -1,3 +1,3 @@
 module Apipie
-  VERSION = '0.5.15'
+  VERSION = '0.5.16'
 end

--- a/spec/controllers/extended_controller_spec.rb
+++ b/spec/controllers/extended_controller_spec.rb
@@ -7,5 +7,8 @@ describe ExtendedController do
     user_param = Apipie["extended#create"].params[:user]
     expect(user_param.validator.params_ordered.map(&:name)).to eq [:name, :password, :from_concern]
   end
-end
 
+  it 'should include updated metadata' do
+    expect(Apipie['extended#create'].metadata).to eq metadata: 'data'
+  end
+end

--- a/spec/controllers/memes_controller_spec.rb
+++ b/spec/controllers/memes_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe TestEngine::MemesController do
+
+  describe "#index" do
+    it "should have the full mounted path of engine" do
+      Apipie.routes_for_action(TestEngine::MemesController, :index, {}).first[:path].should eq("/test/memes")
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -488,12 +488,24 @@ describe UsersController do
           }
         end
 
+        let(:expected_header_with_default) do
+          {
+            name: :HeaderNameWithDefaultValue,
+            description: 'Header with default value',
+            options: {
+              required: true,
+              default: 'default value'
+            }
+          }
+        end
+
         it 'contains all headers description in method doc' do
           headers = Apipie.get_method_description(UsersController, :action_with_headers).headers
           expect(headers).to be_an(Array)
 
           compare_hashes headers[0], expected_required_header
           compare_hashes headers[1], expected_optional_header
+          compare_hashes headers[2], expected_header_with_default
         end
       end
 

--- a/spec/dummy/app/controllers/concerns/extending_concern.rb
+++ b/spec/dummy/app/controllers/concerns/extending_concern.rb
@@ -6,6 +6,7 @@ module Concerns
       param :user, Hash do
         param :from_concern, String, :desc => 'param from concern', :allow_nil => false
       end
+      meta metadata: 'data'
     end
   end
 end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -292,6 +292,7 @@ class UsersController < ApplicationController
   api :GET, '/users/action_with_headers'
   header :RequredHeaderName, 'Required header description', required: true
   header :OptionalHeaderName, 'Optional header description', required: false, type: 'string'
+  header :HeaderNameWithDefaultValue, 'Header with default value', required: true, default: 'default value'
   def action_with_headers
   end
 end

--- a/spec/dummy/components/test_engine/Gemfile
+++ b/spec/dummy/components/test_engine/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+# Declare your gem's dependencies in test_engine.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec

--- a/spec/dummy/components/test_engine/app/controllers/test_engine/application_controller.rb
+++ b/spec/dummy/components/test_engine/app/controllers/test_engine/application_controller.rb
@@ -1,0 +1,4 @@
+module TestEngine
+  class ApplicationController < ActionController::Base
+  end
+end

--- a/spec/dummy/components/test_engine/app/controllers/test_engine/memes_controller.rb
+++ b/spec/dummy/components/test_engine/app/controllers/test_engine/memes_controller.rb
@@ -1,0 +1,37 @@
+module TestEngine
+  class MemesController < TestEngine::ApplicationController
+    api! 'Returns a list of all good memes on Twitter'
+    param :api_token, String, required: true, desc: 'Your Twitter API token'
+    def index
+      render json: []
+    end
+
+    api! 'Shows info about a particular meme on Twitter'
+    param :id, :number, required: true, desc: 'ID of the meme'
+    def show
+      render json: {id: params[:id]}
+    end
+
+    api! 'Create a new meme on Twitter'
+    param :api_token, String, required: true, desc: 'Your Twitter API token'
+    param :name, String, required: true, desc: 'Name of your meme'
+    param :src_url, String, required: true, desc: 'URL for your meme'
+    def create
+      render json: {name: params[:name], src_url: params[:src_url]}, status: :created
+    end
+
+    api! 'Update a meme on Twitter'
+    param :api_token, String, required: true, desc: 'Your Twitter API token'
+    param :name, String, required: false, desc: 'Name of your meme'
+    param :src_url, String, required: false, desc: 'URL for your meme'
+    def update
+      render json: {name: params[:name], src_url: params[:src_url]}
+    end
+
+    api! 'Delete a meme on Twitter'
+    param :id, :number, required: true, desc: 'ID of the meme'
+    def destroy
+      head :ok
+    end
+  end
+end

--- a/spec/dummy/components/test_engine/config/routes.rb
+++ b/spec/dummy/components/test_engine/config/routes.rb
@@ -1,0 +1,3 @@
+TestEngine::Engine.routes.draw do
+  resources :memes, only: [:index, :show, :create, :update, :destroy]
+end

--- a/spec/dummy/components/test_engine/lib/test_engine.rb
+++ b/spec/dummy/components/test_engine/lib/test_engine.rb
@@ -1,0 +1,7 @@
+require 'apipie-rails'
+
+module TestEngine
+  class Engine < ::Rails::Engine
+    isolate_namespace TestEngine
+  end
+end

--- a/spec/dummy/components/test_engine/test_engine.gemspec
+++ b/spec/dummy/components/test_engine/test_engine.gemspec
@@ -1,0 +1,11 @@
+$:.push File.expand_path('../lib', __FILE__)
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = 'test_engine'
+  s.version     = '0.0.1'
+  s.summary     = 'Test Engine'
+  s.authors     = 'Test Author'
+
+  s.files = Dir['{app,config,db,lib}/**/*']
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -8,6 +8,7 @@ require "action_mailer/railtie"
 
 Bundler.require
 require "apipie-rails"
+require "test_engine"
 
 module Dummy
   class Application < Rails::Application

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Dummy::Application.routes.draw do
 
+  mount TestEngine::Engine => '/test'
+
   scope ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
 
     scope '/api' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 
 require 'apipie-rails'
+require 'test_engine'
 
 module Rails4Compatibility
   module Testing


### PR DESCRIPTION
This commit:

- Upgrade the base gem to `v0.5.17`
- Applies Hunter's streaming fix
- Bumps the version to `v0.5.17.1`
  - Hopefully using a patch version instead of minor will help prevent unintended upgrades.

[NOVU-32870](https://mynovu.atlassian.net/browse/NOVU-32870)

@novu/purple 